### PR TITLE
riq-partialify -> partialify

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "http-proxy": "~1.13.2",
     "jquery": "~2.1.0",
     "node-sass": "~3.4.2",
-    "riq-partialify": "~3.1.6",
+    "partialify": "~3.1.6",
     "shallow-diff": "0.0.5",
     "tap-min": "~1.1.0",
     "tiny-lr": "~0.2.1",
@@ -45,7 +45,7 @@
   "browserify-shim": {},
   "browserify": {
     "transform": [
-      "riq-partialify"
+      "partialify"
     ]
   },
   "author": "Danyaal Rangwala <danyaal@rangwa.la>",


### PR DESCRIPTION
`riq-partialify` is a private dependency and in order to actually be open source, we can't use it. Good thing `partialify` works for us! 😄 😄 

Resolves issue #3 
